### PR TITLE
Update broken links and add new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A curated list of bookmarks, packages, tutorials, videos and other cool resource
 ## Tutorials
 * [Chapel Primers](https://chapel-lang.org/docs/master/primers/index.html)
 * [Learn Chapel in Y Minutes](https://learnxinyminutes.com/docs/chapel/)
-* [Idioms and Patterns](https://github.com/chapel-lang/chapel/tree/master/test/release/examples/programs)
+* [Idioms and Patterns](https://github.com/chapel-lang/chapel/tree/master/test/release/examples)
+* [HPC Chapel](https://github.com/hpc-carpentry/hpc-chapel)
 
 ## Chapel On Web
 * [Powerful and Productive Parallel Programming With Chapel: Building an Open-Source Language That Scales From Laptops to Supercomputers](http://www.hostingadvice.com/blog/powerful-and-productive-parallel-programming-with-chapel/)
@@ -30,6 +31,7 @@ A curated list of bookmarks, packages, tutorials, videos and other cool resource
 ## Videos
 
 * [Youtube Channel](https://www.youtube.com/channel/UCHmm27bYjhknK5mU7ZzPGsQ)
+* [CHIUW 2020: Chapel 101](https://www.youtube.com/watch?v=w9AJZuCJ090&t=62s)
 * [Chapel Productive, Multiresolution Parallel Programming | Brad Chamberlain, Cray, Inc.](https://www.youtube.com/watch?v=0DjIdRJIqRY)
 * [CHIUW 2016 keynote: "Chapel in the (Cosmological) Wild", Nikhil Padmanabhan](https://www.youtube.com/watch?v=pnKLp0BTPks)
 
@@ -42,7 +44,7 @@ A curated list of bookmarks, packages, tutorials, videos and other cool resource
 * [chplvis: Chapel communication debug tool](https://chapel-lang.org/docs/latest/tools/chplvis/chplvis.html)
 
 ### Benchmark and Performance
-* [The Computer Language Benchmarks Game](http://benchmarksgame.alioth.debian.org/u64q/chapel.html)
+* [The Computer Language Benchmarks Game](https://benchmarksgame-team.pages.debian.net/benchmarksgame/measurements/chapel.html)
 * [The Computer Language Benchmarks Game Sources](https://github.com/chapel-lang/chapel/blob/master/test/studies/shootout/submitted/README.md)
 * [Chapel Developers Performance Tracking](https://chapel-lang.org/perf/)
 


### PR DESCRIPTION
- I tried to fix broken links such as `Idioms and Patterns` and `The Computer Language Benchmarks Game`.
- Also I added two links that I have found especial useful: [HPC Chapel](https://github.com/hpc-carpentry/hpc-chapel) and [CHIUW 2020: Chapel 101](https://www.youtube.com/watch?v=w9AJZuCJ090&t=62s)